### PR TITLE
bump simple-get to 4.0.1 to fix CVE-2022-0355

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reddit",
   "description": "Simple Reddit API client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "simple-get": "^3.1.0"
+    "simple-get": "^4.0.1"
   },
   "devDependencies": {
     "standard": "*"


### PR DESCRIPTION
https://github.com/advisories/GHSA-wpg7-2c88-r8xv